### PR TITLE
fix: SizeValue interface ts error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,10 +60,10 @@ declare namespace Croppr {
     height: number
   }
 
-  export interface SizeValue extends Array<string | number> {
+  export interface SizeValue extends Array<string | number | undefined> {
     0: number,
     1: number,
-    2?: 'px' | '%'
+    2?: 'px' | '%' | undefined
   }
 
 }


### PR DESCRIPTION
Fix error TS2412: Property '2' of type '"px" | "%" | undefined' is not assignable to numeric index type 'string | number'.